### PR TITLE
Updated layout.css file

### DIFF
--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -296,7 +296,7 @@ h4 {
   color: inherit;
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
     Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
-  font-weight: bold;
+  font-weight: none;
   text-rendering: optimizeLegibility;
   font-size: 1rem;
   line-height: 1.1;
@@ -594,4 +594,31 @@ pre tt:after {
   html {
     font-size: 100%;
   }
+}
+
+.nav-item{
+  display:grid;
+  grid-template-columns: 0.8fr auto 0.1fr;
+  align-items:center;
+}
+
+.nav-links{
+  display:grid;
+  grid-template-columns: repeat(3, 100px);
+  justify-self: end;
+}
+
+.home:hover{
+  text-decoration:underline;
+  color: #202020;
+}
+
+.page2:hover{
+  text-decoration:underline;
+  color: #202020;
+}
+
+.typescript:hover{
+  text-decoration:underline;
+  color: #202020;
 }


### PR DESCRIPTION
-Styled the navigation links to be side-by-side and on the right side of the header bar (using grid-template-columns and justify self).
- Also added a hover feature where hovering on the navigation links will underline them.